### PR TITLE
[FEAT] 로그인한 사용자의 정보를 응답하는 API 구현

### DIFF
--- a/BE/accounts/serializers.py
+++ b/BE/accounts/serializers.py
@@ -77,3 +77,13 @@ class LoginSirializer(serializers.Serializer):
         # 이후 view에서 꺼내서 사용할 수 있도록 user를 넣어두기
         attributes["user"] = user
         return attributes
+    
+
+class MeSerializer(serializers.ModelSerializer):
+    """
+    현재 로그인한 사용자 정보를 조회하는 Serializer
+    """
+    class Meta:
+        model = User
+        fields = ["id", "username", ]
+        read_only_fields = fields

--- a/BE/accounts/urls.py
+++ b/BE/accounts/urls.py
@@ -5,8 +5,13 @@ from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
 urlpatterns = [
     # as_view 메서드가 클래스로 구성되어있는 view를 마치 함수처럼 동작하게 만듦
     path("signup/", views.SignupAPIView.as_view()),
+
     # JWT 로그인(username + password -> access, refresh 발급)
     path("jwt/login/", TokenObtainPairView.as_view()),
+
     # (access 만료 시 refresh로 재발급)
     path("jwt/refresh/", TokenRefreshView.as_view()),
+
+    # 회원 정보 조회
+    path("me/", views.MeAPIView.as_view()),
 ]

--- a/BE/accounts/views.py
+++ b/BE/accounts/views.py
@@ -1,8 +1,10 @@
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework import status
-from .serializers import SignupSerializer, LoginSirializer
+from .serializers import SignupSerializer, LoginSirializer, MeSerializer
 from django.contrib.auth import login
+from rest_framework.permissions import IsAuthenticated
+
 
 class SignupAPIView(APIView):
     """
@@ -57,3 +59,15 @@ class LoginAPIView(APIView):
             )
         # 유효성 검사 실패 시 에러 응답
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+    
+
+class MeAPIView(APIView):
+    """
+    GET /auth/me/ -> JWT로 로그인된 사용자의 정보를 반환
+    """
+
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request):
+        serializer = MeSerializer(request.user)
+        return Response(serializer.data)


### PR DESCRIPTION
작업개요
로그인한 사용자의 정보를 응답하는 api 구현

변경사항
차후에 마이페이지, 만든 경로, 작성한 게시글 등 조회를 위해 사용자의 정보를 응답하는 api를 구현하였습니다.

확인요청
로그인 후 다음의 경로로 요청을 보냅니다.
http://127.0.0.1:80/auth/me/

아래처럼 응답이 오면 성공입니다.
<img width="1770" height="1194" alt="image" src="https://github.com/user-attachments/assets/a9b42934-e383-4a41-853e-2bb966e171d0" />
